### PR TITLE
Corrected some formatting errors found with golang parser

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Data/presto_max_v5.txt filter=lfs diff=lfs merge=lfs -text

--- a/Data/presto_max_v5.txt
+++ b/Data/presto_max_v5.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:19aaa88da3dfb82d58ccf9b55ce78bd8a0371cf708cf05d4e2ab10cd92f562a1
-size 111909603
+oid sha256:1e7afe0fce077766fcdf6017c7e0808a0743a9b8e8fa17c8ba5b140af7db7850
+size 111909786


### PR DESCRIPTION
I was able to correct some formatting and annotation errors in the `presto_max_v5.txt` using a golang parser I made.

I also added the `.gitattributes` in order to keep track of the `presto_max_v5.txt` file with Git LFS.